### PR TITLE
Add Dockerfile for Quip MCP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 # install python and quip library
 RUN apt-get update && \
     apt-get install -y --no-install-recommends python3 python3-pip && \
-    pip3 install --no-cache-dir quip && \
+    pip3 install --break-system-packages --no-cache-dir quip && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /app/node_modules ./node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Build stage
+FROM node:20 AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM node:20-slim
+WORKDIR /app
+# install python and quip library
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3 python3-pip && \
+    pip3 install --no-cache-dir quip && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/build ./build
+COPY scripts ./scripts
+
+ENV NODE_ENV=production
+CMD ["node", "build/index.js"]

--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ This MCP server acts as a bridge between Claude and Quip documents. It works by:
 
 ## Docker
 
-The provided `Dockerfile` uses Node.js 20 with a slim runtime image and installs
-Python along with the `quip` library. Build the container image and run it with
+The included `Dockerfile` builds the MCP using Node.js 20 and a slim runtime.
+It also installs Python and the `quip` library required by the server. To
+install and run the MCP via Docker, build the image and start a container with
 your Quip credentials:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -76,6 +76,27 @@ docker run --rm \
   quip-mcp-server
 ```
 
+To configure your MCP to launch the server via Docker, reference the built
+image in your `mcpServers` settings:
+
+```json
+{
+  "mcpServers": {
+    "quip": {
+      "command": "docker",
+      "args": [
+        "run", "--rm",
+        "-e", "QUIP_ACCESS_TOKEN=your-quip-access-token",
+        "-e", "QUIP_BASE_URL=https://platform.quip.com",
+        "quip-mcp-server"
+      ],
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}
+```
+
 ## Usage
 
 Once connected, the following MCP tools become available to Claude:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ This MCP server acts as a bridge between Claude and Quip documents. It works by:
    }
    ```
 
+## Docker
+
+The provided `Dockerfile` uses Node.js 20 with a slim runtime image and installs
+Python along with the `quip` library. Build the container image and run it with
+your Quip credentials:
+
+```bash
+docker build -t quip-mcp-server .
+docker run --rm \
+  -e QUIP_ACCESS_TOKEN=your-quip-access-token \
+  -e QUIP_BASE_URL=https://platform.quip.com \
+  quip-mcp-server
+```
+
 ## Usage
 
 Once connected, the following MCP tools become available to Claude:


### PR DESCRIPTION
## Summary
- add Dockerfile for building and running the server
- document Docker usage in README
- update to node:20-slim runtime

## Testing
- `npm run build`
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a10eb9980832ea680c6c1cd524469